### PR TITLE
Fixes for issue #9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.4'
-          - '1.5'
           - '1.6'
+          - '1.7'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Artifacts = "1.3"
 JSON3 = "1.8"
 Librsvg_jll = "2.52"
 NodeJS = "1.1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ NodeJS = "2bd173c7-0d6d-553b-b6af-13a54713934c"
 [compat]
 Artifacts = "1.3"
 JSON3 = "1.8"
-Librsvg_jll = "2.42"
+Librsvg_jll = "2.52"
 NodeJS = "1.1"
 julia = "1.3"
 

--- a/src/MathJaxRenderer.jl
+++ b/src/MathJaxRenderer.jl
@@ -31,7 +31,7 @@ either `show` or `write`:
       - `keep_aspect_ratio = false`, whether to preserve the aspect ratio.
       - `background_color = :white`, set the background color, CSS color names and syntax.
       - `unlimited = false`, allow for huge SVG files.
-      - `rsvg_convert_bin = ""`, use custom rsvg_convert binary (an empty string uses Librsvg_jll binary)
+      - `rsvg_convert_bin = nothing`, use custom rsvg_convert binary (nothing uses Librsvg_jll binary)
 
 When writing to file with `write` the follow extensions are supported:
 
@@ -137,11 +137,11 @@ function converter(
     keep_aspect_ratio = false,
     background_color = :white,
     unlimited = false,
-    rsvg_convert_bin = "",
+    rsvg_convert_bin = nothing,
     kws...,
 )
     Librsvg_jll.rsvg_convert() do bin
-        if !isempty(rsvg_convert_bin)
+        if !isnothing(rsvg_convert_bin) && !isnothing(Sys.which(rsvg_convert_bin))
             bin = rsvg_convert_bin
         end
         cmd = [

--- a/src/MathJaxRenderer.jl
+++ b/src/MathJaxRenderer.jl
@@ -28,10 +28,10 @@ either `show` or `write`:
       - `dpi_y = 90`, pixels per inch (vertical).
       - `x_zoom = 1.0`, zoom factor (horizontal).
       - `y_zoom = 1.0`, zoom factor (vertical).
-      - `zoom = 1.0`, zoom factor (both horizontal and vertical).
       - `keep_aspect_ratio = false`, whether to preserve the aspect ratio.
       - `background_color = :white`, set the background color, CSS color names and syntax.
       - `unlimited = false`, allow for huge SVG files.
+      - `rsvg_convert_bin = ""`, use custom rsvg_convert binary (an empty string uses Librsvg_jll binary)
 
 When writing to file with `write` the follow extensions are supported:
 
@@ -126,6 +126,7 @@ function svg_converter(
     return IOBuffer(extract_svg(str))
 end
 
+
 function converter(
     f::Math,
     m::SUPPORTED_MIMES;
@@ -133,14 +134,16 @@ function converter(
     dpi_y = 90,
     x_zoom = 1.0,
     y_zoom = 1.0,
-    zoom = 1.0,
     keep_aspect_ratio = false,
     background_color = :white,
     unlimited = false,
+    rsvg_convert_bin = "",
     kws...,
 )
     Librsvg_jll.rsvg_convert() do bin
-        ext = extension(m)
+        if !isempty(rsvg_convert_bin)
+            bin = rsvg_convert_bin
+        end
         cmd = [
             bin,
             "--format=$(extension(m))",
@@ -148,7 +151,6 @@ function converter(
             "--dpi-y=$dpi_y",
             "--x-zoom=$x_zoom",
             "--y-zoom=$y_zoom",
-            "--zoom=$zoom",
             "--background-color=$background_color",
         ]
         keep_aspect_ratio && push!(cmd, "--keep-aspect-ratio")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,11 +4,13 @@ using Test, MathJaxRenderer, VisualRegressionTests
 
 keywords = Dict(
     "small" => (
-        zoom = 4,
+        x_zoom = 4,
+        y_zoom = 4,
         background_color = :orange,
     ),
     "large" => (
-        zoom = 2,
+        x_zoom = 2,
+        y_zoom = 2,
         background_color = :lightblue,
     ),
 )
@@ -28,9 +30,9 @@ keywords = Dict(
         end
     end
     @testset "Visuals" begin
-        testfun = (filename) -> write(filename, Math("\\frac{1}{1 + x}"); zoom = 5)
-        @visualtest testfun joinpath(@__DIR__, "data/references/fraction.png") tol = 0.2
-        testfun = (filename) -> write(filename, Math("\\begin{align}\n3.29e+07 =& 1.23e+00 =& P_{1} \\\\\n\\frac{x}{y} =& 1.00e+10 =& 1.29e+03\n\\end{align}"); zoom = 5)
-        @visualtest testfun joinpath(@__DIR__, "data/references/align.png") tol = 0.2
+        testfun = (filename) -> write(filename, Math("\\frac{1}{1 + x}"); x_zoom = 5, y_zoom = 5)
+        @visualtest testfun joinpath(@__DIR__, "data/references/fraction.png") popup = false tol = 0.2
+        testfun = (filename) -> write(filename, Math("\\begin{align}\n3.29e+07 =& 1.23e+00 =& P_{1} \\\\\n\\frac{x}{y} =& 1.00e+10 =& 1.29e+03\n\\end{align}"); x_zoom = 5, y_zoom = 5)
+        @visualtest testfun joinpath(@__DIR__, "data/references/align.png") popup = false tol = 0.2
     end
 end


### PR DESCRIPTION
Now that Librsvg_jll is updated MathJaxRenderer has to be updated accordingly.
This PR
- Resolves the zoom issue for newer versions of rsvg-convert
- Allows a user to provide a custom rsvg-convert binary as optional keyword argument 